### PR TITLE
[#54] Bump version to 0.2.0

### DIFF
--- a/.github/workflows/deploy_android_production.yml
+++ b/.github/workflows/deploy_android_production.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Get Flutter dependencies
       run: flutter pub get
 
+    - name: Upgrade Flutter packages
+      run: flutter packages upgrade
+
     - name: Run code generator script
       run: flutter packages pub run build_runner build --delete-conflicting-outputs
 

--- a/.github/workflows/deploy_android_staging.yml
+++ b/.github/workflows/deploy_android_staging.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Get Flutter dependencies
       run: flutter pub get
 
+    - name: Upgrade Flutter packages
+      run: flutter packages upgrade
+
     - name: Run code generator script
       run: flutter packages pub run build_runner build --delete-conflicting-outputs
 

--- a/.github/workflows/deploy_ios_production.yml
+++ b/.github/workflows/deploy_ios_production.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Get Flutter dependencies
       run: flutter pub get
 
+    - name: Upgrade Flutter packages
+      run: flutter packages upgrade
+
     - name: Run code generator
       run: flutter packages pub run build_runner build --delete-conflicting-outputs
 

--- a/.github/workflows/deploy_ios_staging.yml
+++ b/.github/workflows/deploy_ios_staging.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Get Flutter dependencies
       run: flutter pub get
 
+    - name: Upgrade Flutter packages
+      run: flutter packages upgrade
+
     - name: Run code generator script
       run: flutter packages pub run build_runner build --delete-conflicting-outputs
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.1.0+1
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.17.5 <3.0.0"


### PR DESCRIPTION
- Close #54

## Insight 📝

- Bump version to 0.2.0
- Upgrade Flutter packages for the deploying pipelines
