### PR TITLE
[#9] [Integration] As a user, I can perform the OAuth while sending any API request

### DIFF
--- a/lib/api/oauth_service.dart
+++ b/lib/api/oauth_service.dart
@@ -1,7 +1,9 @@
 import 'package:dio/dio.dart';
-import 'package:retrofit/retrofit.dart';
 import 'package:kayla_flutter_ic/api/request/oauth_login_request.dart';
+import 'package:kayla_flutter_ic/api/request/oauth_refresh_token_request.dart';
 import 'package:kayla_flutter_ic/api/response/oauth_login_response.dart';
+import 'package:kayla_flutter_ic/api/response/oauth_refresh_token_response.dart';
+import 'package:retrofit/retrofit.dart';
 
 part 'oauth_service.g.dart';
 
@@ -12,5 +14,10 @@ abstract class OAuthService {
   @POST('/api/v1/oauth/token')
   Future<OAuthLoginResponse> login(
     @Body() OAuthLoginRequest body,
+  );
+
+  @POST('/api/v1/oauth/token')
+  Future<OAuthRefreshTokenResponse> refreshToken(
+    @Body() OAuthRefreshTokenRequest body,
   );
 }

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:kayla_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:kayla_flutter_ic/api/oauth_service.dart';
 import 'package:kayla_flutter_ic/api/request/oauth_login_request.dart';
+import 'package:kayla_flutter_ic/api/request/oauth_refresh_token_request.dart';
 import 'package:kayla_flutter_ic/env.dart';
 import 'package:kayla_flutter_ic/model/oauth_login.dart';
 
@@ -9,6 +10,10 @@ abstract class OAuthRepository {
   Future<OAuthLogin> login({
     required String email,
     required String password,
+  });
+
+  Future<OAuthLogin> refreshToken({
+    required String refreshToken,
   });
 }
 
@@ -33,6 +38,30 @@ class OAuthRepositoryImpl extends OAuthRepository {
           grantType: OAuthLoginRequest.passwordGrantType,
         ),
       );
+      return OAuthLogin(
+        id: response.id,
+        tokenType: response.tokenType,
+        accessToken: response.accessToken,
+        expiresIn: response.expiresIn,
+        refreshToken: response.refreshToken,
+      );
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<OAuthLogin> refreshToken({
+    required String refreshToken,
+  }) async {
+    try {
+      final response =
+          await _oauthService.refreshToken(OAuthRefreshTokenRequest(
+        refreshToken: refreshToken,
+        clientId: Env.clientId,
+        clientSecret: Env.clientSecret,
+        grantType: OAuthRefreshTokenRequest.refreshTokenGrantType,
+      ));
       return OAuthLogin(
         id: response.id,
         tokenType: response.tokenType,

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -5,6 +5,7 @@ import 'package:kayla_flutter_ic/api/request/oauth_login_request.dart';
 import 'package:kayla_flutter_ic/api/request/oauth_refresh_token_request.dart';
 import 'package:kayla_flutter_ic/env.dart';
 import 'package:kayla_flutter_ic/model/oauth_login.dart';
+import 'package:kayla_flutter_ic/model/oauth_refresh_token.dart';
 
 abstract class OAuthRepository {
   Future<OAuthLogin> login({
@@ -12,7 +13,7 @@ abstract class OAuthRepository {
     required String password,
   });
 
-  Future<OAuthLogin> refreshToken({
+  Future<OAuthRefreshToken> refreshToken({
     required String refreshToken,
   });
 }
@@ -51,7 +52,7 @@ class OAuthRepositoryImpl extends OAuthRepository {
   }
 
   @override
-  Future<OAuthLogin> refreshToken({
+  Future<OAuthRefreshToken> refreshToken({
     required String refreshToken,
   }) async {
     try {
@@ -62,7 +63,7 @@ class OAuthRepositoryImpl extends OAuthRepository {
         clientSecret: Env.clientSecret,
         grantType: OAuthRefreshTokenRequest.refreshTokenGrantType,
       ));
-      return OAuthLogin(
+      return OAuthRefreshToken(
         id: response.id,
         tokenType: response.tokenType,
         accessToken: response.accessToken,

--- a/lib/api/request/oauth_refresh_token_request.dart
+++ b/lib/api/request/oauth_refresh_token_request.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'oauth_refresh_token_request.g.dart';
+
+@JsonSerializable()
+class OAuthRefreshTokenRequest {
+  static const String refreshTokenGrantType = 'refresh_token';
+
+  @JsonKey(name: 'refresh_token')
+  final String refreshToken;
+  @JsonKey(name: 'client_id')
+  final String clientId;
+  @JsonKey(name: 'client_secret')
+  final String clientSecret;
+  @JsonKey(name: 'grant_type')
+  final String grantType;
+
+  OAuthRefreshTokenRequest({
+    required this.refreshToken,
+    required this.clientId,
+    required this.clientSecret,
+    required this.grantType,
+  });
+
+  factory OAuthRefreshTokenRequest.fromJson(Map<String, dynamic> json) =>
+      _$OAuthRefreshTokenRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$OAuthRefreshTokenRequestToJson(this);
+}

--- a/lib/api/response/oauth_refresh_token_response.dart
+++ b/lib/api/response/oauth_refresh_token_response.dart
@@ -1,0 +1,28 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:kayla_flutter_ic/api/response/base_response_converter.dart';
+
+part 'oauth_refresh_token_response.g.dart';
+
+@JsonSerializable()
+class OAuthRefreshTokenResponse {
+  final String id;
+  final String type;
+  final String accessToken;
+  final String tokenType;
+  final double expiresIn;
+  final String refreshToken;
+  final double createdAt;
+
+  OAuthRefreshTokenResponse({
+    required this.id,
+    required this.type,
+    required this.accessToken,
+    required this.tokenType,
+    required this.expiresIn,
+    required this.refreshToken,
+    required this.createdAt,
+  });
+
+  factory OAuthRefreshTokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$OAuthRefreshTokenResponseFromJson(fromJsonApi(json));
+}

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -2,6 +2,10 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
+import 'package:kayla_flutter_ic/di/di.dart';
+import 'package:kayla_flutter_ic/model/oauth_refresh_token.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+import 'package:kayla_flutter_ic/usecases/oath/refresh_token_use_case.dart';
 
 const _headerAuthorization = 'Authorization';
 
@@ -45,25 +49,21 @@ class AppInterceptor extends Interceptor {
     ErrorInterceptorHandler handler,
   ) async {
     try {
-      // TODO Request new token
-
-      // if (result is Success) {
-      // TODO Update new token header
-      // err.requestOptions.headers[_headerAuthorization] = newToken;
-
-      // Create request with new access token
-      final options = Options(
-          method: err.requestOptions.method,
-          headers: err.requestOptions.headers);
-      final newRequest = await _dio.request(
-          "${err.requestOptions.baseUrl}${err.requestOptions.path}",
-          options: options,
-          data: err.requestOptions.data,
-          queryParameters: err.requestOptions.queryParameters);
-      handler.resolve(newRequest);
-      //  } else {
-      //    handler.next(err);
-      //  }
+      final result = await _requestNewTokens();
+      if (result is Success<OAuthRefreshToken>) {
+        err.requestOptions.headers[_headerAuthorization] = _tokens;
+        final options = Options(
+            method: err.requestOptions.method,
+            headers: err.requestOptions.headers);
+        final newRequest = await _dio.request(
+            "${err.requestOptions.baseUrl}${err.requestOptions.path}",
+            options: options,
+            data: err.requestOptions.data,
+            queryParameters: err.requestOptions.queryParameters);
+        handler.resolve(newRequest);
+      } else {
+        handler.next(err);
+      }
     } catch (exception) {
       if (exception is DioError) {
         handler.next(exception);
@@ -78,5 +78,10 @@ class AppInterceptor extends Interceptor {
     final accessToken = await _secureStorage.accessToken;
     if (tokenType == null || accessToken == null) return '';
     return '$tokenType $accessToken';
+  }
+
+  Future<Result<OAuthRefreshToken>> _requestNewTokens() {
+    final refreshTokenUseCase = getIt<RefreshTokenUseCase>();
+    return refreshTokenUseCase.call();
   }
 }

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -1,23 +1,29 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
+
+const _headerAuthorization = 'Authorization';
 
 class AppInterceptor extends Interceptor {
   final bool _requireAuthenticate;
   final Dio _dio;
+  final SecureStorage _secureStorage;
 
   AppInterceptor(
     this._requireAuthenticate,
     this._dio,
+    this._secureStorage,
   );
 
   @override
   Future onRequest(
-      RequestOptions options, RequestInterceptorHandler handler) async {
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
     if (_requireAuthenticate) {
-      // TODO header authorization here
-      // options.headers
-      //     .putIfAbsent(HEADER_AUTHORIZATION, () => "");
+      String tokens = await _tokens;
+      options.headers.putIfAbsent(_headerAuthorization, () => tokens);
     }
     return super.onRequest(options, handler);
   }
@@ -65,5 +71,12 @@ class AppInterceptor extends Interceptor {
         handler.next(err);
       }
     }
+  }
+
+  Future<String> get _tokens async {
+    final tokenType = await _secureStorage.tokenType;
+    final accessToken = await _secureStorage.accessToken;
+    if (tokenType == null || accessToken == null) return '';
+    return '$tokenType $accessToken';
   }
 }

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:flutter/foundation.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
 import 'package:kayla_flutter_ic/di/interceptor/app_interceptor.dart';
 
 const String headerContentType = 'Content-Type';
@@ -10,6 +11,11 @@ const String defaultContentType = 'application/json; charset=utf-8';
 class DioProvider {
   Dio? _nonAuthenticatedDio;
   Dio? _authenticatedDio;
+  final SecureStorage _secureStorage;
+
+  DioProvider(
+    this._secureStorage,
+  );
 
   Dio getNonAuthenticatedDio() {
     _nonAuthenticatedDio ??= _createDio();
@@ -26,6 +32,7 @@ class DioProvider {
     final appInterceptor = AppInterceptor(
       requireAuthenticate,
       dio,
+      _secureStorage,
     );
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);

--- a/lib/model/oauth_refresh_token.dart
+++ b/lib/model/oauth_refresh_token.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+class OAuthRefreshToken extends Equatable {
+  final String id;
+  final String tokenType;
+  final String accessToken;
+  final double expiresIn;
+  final String refreshToken;
+
+  const OAuthRefreshToken({
+    required this.id,
+    required this.tokenType,
+    required this.accessToken,
+    required this.expiresIn,
+    required this.refreshToken,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        tokenType,
+        accessToken,
+        expiresIn,
+        refreshToken,
+      ];
+}

--- a/lib/usecases/oath/refresh_token_use_case.dart
+++ b/lib/usecases/oath/refresh_token_use_case.dart
@@ -1,0 +1,42 @@
+import 'package:injectable/injectable.dart';
+import 'package:kayla_flutter_ic/api/repository/oauth_repository.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
+import 'package:kayla_flutter_ic/model/oauth_refresh_token.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+
+@Injectable()
+class RefreshTokenUseCase extends NoParamsUseCase<OAuthRefreshToken> {
+  final OAuthRepository _oauthRepository;
+  final SecureStorage _secureStorage;
+
+  const RefreshTokenUseCase(
+    this._oauthRepository,
+    this._secureStorage,
+  );
+
+  @override
+  Future<Result<OAuthRefreshToken>> call() async {
+    try {
+      final refreshToken = await _secureStorage.refreshToken ?? '';
+      final result =
+          await _oauthRepository.refreshToken(refreshToken: refreshToken);
+      return await _storeTokens(result);
+    } catch (exception) {
+      return Failed(UseCaseException(exception));
+    }
+  }
+
+  Future<Result<OAuthRefreshToken>> _storeTokens(
+      OAuthRefreshToken oauthRefreshToken) async {
+    try {
+      await _secureStorage.storeId(oauthRefreshToken.id);
+      await _secureStorage.storeTokenType(oauthRefreshToken.tokenType);
+      await _secureStorage.storeAccessToken(oauthRefreshToken.accessToken);
+      await _secureStorage.storeExpiresIn('${oauthRefreshToken.expiresIn}');
+      await _secureStorage.storeRefreshToken(oauthRefreshToken.refreshToken);
+      return Success(oauthRefreshToken);
+    } catch (exception) {
+      return Failed(UseCaseException(exception));
+    }
+  }
+}


### PR DESCRIPTION
- Close #9

## What happened 👀

To provide a user security mechanism to access server resources, we propose the OAuth 2 standard. Hence, in order to make authenticated API requests, require including the access token for all endpoints.

Include access token value for all endpoints.

## Insight 📝

Include access token value for all endpoints in the app interceptor.

## Proof Of Work 📹

`N/A`
