### PR TITLE
[#15] [UI] As an anonymous user, I can see the forgot password screen

### DIFF
--- a/lib/views/common/build_context_ext.dart
+++ b/lib/views/common/build_context_ext.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:kayla_flutter_ic/views/common/loading_indicator/loading_indicator_dialog.dart';
 
 extension BuildContextExtension on BuildContext {
+  void showSnackBar({required String message}) =>
+      ScaffoldMessenger.of(this).showSnackBar(SnackBar(content: Text(message)));
+
   void showOrHideLoadingIndicator({
     required bool shouldShow,
   }) {

--- a/lib/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart
+++ b/lib/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart
@@ -1,0 +1,41 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class LinearGradientBlurBackground extends StatelessWidget {
+  final Widget image;
+  final AlignmentGeometry begin;
+  final AlignmentGeometry end;
+  final List<Color> colors;
+
+  const LinearGradientBlurBackground({
+    super.key,
+    required this.image,
+    required this.begin,
+    required this.end,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        image,
+        ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+          child: ShaderMask(
+            shaderCallback: (rectangle) {
+              return LinearGradient(
+                begin: begin,
+                end: end,
+                colors: colors,
+              ).createShader(rectangle);
+            },
+            blendMode: BlendMode.overlay,
+            child: image,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/forget_password/forget_password_form.dart
+++ b/lib/views/forget_password/forget_password_form.dart
@@ -99,6 +99,8 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
 
   String? _validateEmailMessage(String? email) {
     ref.read(forgetPasswordViewModelProvider.notifier).validateEmail(email);
-    return ref.read(forgetPasswordViewModelProvider.notifier).emailWarningMessage;
+    return ref
+        .read(forgetPasswordViewModelProvider.notifier)
+        .emailWarningMessage;
   }
 }

--- a/lib/views/forget_password/forget_password_form.dart
+++ b/lib/views/forget_password/forget_password_form.dart
@@ -32,7 +32,6 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
 
   InputDecoration _inputDecoration({
     required String labelText,
-    double rightPadding = 12.0,
   }) {
     return InputDecoration(
       labelText: labelText,
@@ -42,12 +41,8 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
       ),
       fillColor: Colors.white24,
       filled: true,
-      contentPadding: EdgeInsets.only(
-        top: 18.0,
-        bottom: 18.0,
-        left: 12.0,
-        right: rightPadding,
-      ),
+      contentPadding:
+          const EdgeInsets.symmetric(vertical: 18.0, horizontal: 12.0),
     );
   }
 
@@ -98,9 +93,8 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
   }
 
   String? _validateEmailMessage(String? email) {
-    ref.read(forgetPasswordViewModelProvider.notifier).validateEmail(email);
-    return ref
-        .read(forgetPasswordViewModelProvider.notifier)
-        .emailWarningMessage;
+    final viewModel = ref.read(forgetPasswordViewModelProvider.notifier);
+    viewModel.validateEmail(email);
+    return viewModel.emailWarningMessage;
   }
 }

--- a/lib/views/forget_password/forget_password_form.dart
+++ b/lib/views/forget_password/forget_password_form.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/utils/border_radiuses.dart';
+import 'package:kayla_flutter_ic/utils/keyboard.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_view.dart';
+import 'package:kayla_flutter_ic/views/login/login_view.dart';
+
+class ForgetPasswordForm extends ConsumerStatefulWidget {
+  const ForgetPasswordForm({super.key});
+
+  @override
+  ForgetPasswordFormState createState() => ForgetPasswordFormState();
+}
+
+class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
+  final _forgetPasswordFormKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  bool _isStartedValidation = false;
+
+  TextFormField get _emailTextField => TextFormField(
+        keyboardType: TextInputType.emailAddress,
+        decoration: _inputDecoration(labelText: 'Email'),
+        controller: _emailController,
+        validator: _validateEmailMessage,
+      );
+
+  ElevatedButton get _resetButton => ElevatedButton(
+        style: ElevatedButton.styleFrom(minimumSize: const Size(0, 56)),
+        child: const Text('Reset'),
+        onPressed: () => _reset(),
+      );
+
+  InputDecoration _inputDecoration({
+    required String labelText,
+    double rightPadding = 12.0,
+  }) {
+    return InputDecoration(
+      labelText: labelText,
+      border: OutlineInputBorder(
+        borderSide: BorderSide.none,
+        borderRadius: BorderRadiuses.circular12,
+      ),
+      fillColor: Colors.white24,
+      filled: true,
+      contentPadding: EdgeInsets.only(
+        top: 18.0,
+        bottom: 18.0,
+        left: 12.0,
+        right: rightPadding,
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController.addListener(() => ref
+        .read(loginViewModelProvider.notifier)
+        .validateEmail(_emailController.text));
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _forgetPasswordFormKey,
+      autovalidateMode: _isStartedValidation
+          ? AutovalidateMode.onUserInteraction
+          : AutovalidateMode.disabled,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _emailTextField,
+          const SizedBox(height: 20),
+          _resetButton,
+        ],
+      ),
+    );
+  }
+
+  Future<void> _reset() async {
+    setState(() {
+      if (!_isStartedValidation) {
+        _isStartedValidation = true;
+      }
+    });
+    if (!_forgetPasswordFormKey.currentState!.validate()) {
+      return;
+    }
+    Keyboard.hideKeyboard(context);
+    // TODO: - Call API
+  }
+
+  String? _validateEmailMessage(String? email) {
+    ref.read(forgetPasswordViewModelProvider.notifier).validateEmail(email);
+    return ref.read(forgetPasswordViewModelProvider.notifier).emailWarningMessage;
+  }
+}

--- a/lib/views/forget_password/forget_password_form.dart
+++ b/lib/views/forget_password/forget_password_form.dart
@@ -27,7 +27,7 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
   ElevatedButton get _resetButton => ElevatedButton(
         style: ElevatedButton.styleFrom(minimumSize: const Size(0, 56)),
         child: const Text('Reset'),
-        onPressed: () => _reset(),
+        onPressed: () => _forgetPassword(),
       );
 
   InputDecoration _inputDecoration({
@@ -79,7 +79,7 @@ class ForgetPasswordFormState extends ConsumerState<ForgetPasswordForm> {
     );
   }
 
-  Future<void> _reset() async {
+  Future<void> _forgetPassword() async {
     setState(() {
       if (!_isStartedValidation) {
         _isStartedValidation = true;

--- a/lib/views/forget_password/forget_password_state.dart
+++ b/lib/views/forget_password/forget_password_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'forget_password_state.freezed.dart';
+
+@freezed
+class ForgetPasswordState with _$ForgetPasswordState {
+  const factory ForgetPasswordState.init() = _Init;
+
+  const factory ForgetPasswordState.loading() = _Loading;
+
+  const factory ForgetPasswordState.error(String? error) = _Error;
+
+  const factory ForgetPasswordState.success() = _Success;
+}

--- a/lib/views/forget_password/forget_password_view.dart
+++ b/lib/views/forget_password/forget_password_view.dart
@@ -1,0 +1,146 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/gen/assets.gen.dart';
+import 'package:kayla_flutter_ic/views/common/build_context_ext.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_form.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_state.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_view_model.dart';
+
+final forgetPasswordViewModelProvider = StateNotifierProvider.autoDispose<
+    ForgetPasswordViewModel, ForgetPasswordState>(
+  (_) => ForgetPasswordViewModel(),
+);
+
+class ForgetPasswordView extends ConsumerStatefulWidget {
+  const ForgetPasswordView({super.key});
+
+  @override
+  ForgetPasswordViewState createState() => ForgetPasswordViewState();
+}
+
+class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
+    with TickerProviderStateMixin {
+  AppBar get _appBar => AppBar(
+        leading: const BackButton(),
+        backgroundColor: Colors.transparent,
+        shadowColor: Colors.transparent,
+      );
+
+  Widget get _background => SizedBox(
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height,
+        child: Stack(
+          children: [
+            _backgroundImage,
+            _linearGradientBlurBackground,
+          ],
+        ),
+      );
+
+  Widget get _backgroundImage => Image(
+        image: Assets.images.nimbleBackground.image().image,
+        fit: BoxFit.cover,
+        alignment: Alignment.center,
+      );
+
+  Widget get _linearGradientBlurBackground => Stack(
+        children: [
+          _backgroundImage,
+          ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+            child: ShaderMask(
+              shaderCallback: (rectangle) {
+                return LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withOpacity(0.2),
+                    Colors.black.withOpacity(1),
+                  ],
+                ).createShader(rectangle);
+              },
+              blendMode: BlendMode.overlay,
+              child: _backgroundImage,
+            ),
+          ),
+        ],
+      );
+
+  Widget get _logo => SizedBox(
+        width: 166,
+        height: 40,
+        child: FittedBox(
+          fit: BoxFit.contain,
+          child: Image(
+            image: Assets.images.nimbleLogoWhite.image().image,
+            fit: BoxFit.scaleDown,
+          ),
+        ),
+      );
+
+  Widget _intruction(BuildContext context) => Text(
+        'Enter your email to receive instructions for resetting your password.',
+        style: Theme.of(context)
+            .textTheme
+            .bodyMedium
+            ?.copyWith(color: Colors.white70),
+        textAlign: TextAlign.center,
+      );
+
+  Widget get _form => const ForgetPasswordForm();
+
+  @override
+  Widget build(BuildContext context) {
+    _setupStateListener();
+    return _defaultForgetPasswordView();
+  }
+
+  Widget _defaultForgetPasswordView() {
+    return Stack(
+      children: [
+        _background,
+        Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: _appBar,
+          body: SafeArea(
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 30, horizontal: 24),
+              child: Column(
+                children: [
+                  const SizedBox(height: 60),
+                  _logo,
+                  const SizedBox(height: 20),
+                  _intruction(context),
+                  const SizedBox(height: 100),
+                  _form,
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _setupStateListener() {
+    ref.listen<ForgetPasswordState>(forgetPasswordViewModelProvider,
+        (_, state) {
+      context.showOrHideLoadingIndicator(
+        shouldShow: state == const ForgetPasswordState.loading(),
+      );
+      state.maybeWhen(
+        error: (error) {
+          ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Please try again. $error.')));
+        },
+        success: () async {
+          // TODO: - Show the notification widget
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('Check your email')));
+        },
+        orElse: () {},
+      );
+    });
+  }
+}

--- a/lib/views/forget_password/forget_password_view.dart
+++ b/lib/views/forget_password/forget_password_view.dart
@@ -1,8 +1,8 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/views/common/build_context_ext.dart';
+import 'package:kayla_flutter_ic/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart';
 import 'package:kayla_flutter_ic/views/forget_password/forget_password_form.dart';
 import 'package:kayla_flutter_ic/views/forget_password/forget_password_state.dart';
 import 'package:kayla_flutter_ic/views/forget_password/forget_password_view_model.dart';
@@ -44,28 +44,14 @@ class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
         alignment: Alignment.center,
       );
 
-  Widget get _linearGradientBlurBackground => Stack(
-        children: [
-          _backgroundImage,
-          ImageFiltered(
-            imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-            child: ShaderMask(
-              shaderCallback: (rectangle) {
-                return LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.black.withOpacity(0.2),
-                    Colors.black.withOpacity(1),
-                  ],
-                ).createShader(rectangle);
-              },
-              blendMode: BlendMode.overlay,
-              child: _backgroundImage,
-            ),
-          ),
-        ],
-      );
+  Widget get _linearGradientBlurBackground => LinearGradientBlurBackground(
+          image: _backgroundImage,
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Colors.black.withOpacity(0.2),
+            Colors.black.withOpacity(1),
+          ]);
 
   Widget get _logo => SizedBox(
         width: 166,
@@ -79,7 +65,7 @@ class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
         ),
       );
 
-  Widget _intruction(BuildContext context) => Text(
+  Widget _instruction(BuildContext context) => Text(
         'Enter your email to receive instructions for resetting your password.',
         style: Theme.of(context)
             .textTheme
@@ -111,7 +97,7 @@ class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
                   const SizedBox(height: 60),
                   _logo,
                   const SizedBox(height: 20),
-                  _intruction(context),
+                  _instruction(context),
                   const SizedBox(height: 100),
                   _form,
                 ],
@@ -131,13 +117,11 @@ class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
       );
       state.maybeWhen(
         error: (error) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Please try again. $error.')));
+          context.showSnackBar(message: 'Please try again. $error.');
         },
         success: () async {
           // TODO: - Show the notification widget
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Check your email')));
+          context.showSnackBar(message: 'Check your email.');
         },
         orElse: () {},
       );

--- a/lib/views/forget_password/forget_password_view_model.dart
+++ b/lib/views/forget_password/forget_password_view_model.dart
@@ -1,0 +1,31 @@
+import 'package:email_validator/email_validator.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_state.dart';
+
+class ForgetPasswordViewModel extends StateNotifier<ForgetPasswordState> {
+  String? get emailWarningMessage => _emailWarningMessage;
+
+  String? _emailWarningMessage;
+
+  ForgetPasswordViewModel() : super(const ForgetPasswordState.init());
+
+  void validateEmail(String? email) {
+    if (email == null || email.isEmpty) {
+      _emailWarningMessage = 'Please enter your email!';
+    } else if (!EmailValidator.validate(email)) {
+      _emailWarningMessage = 'Wrong email format.';
+    } else {
+      _emailWarningMessage = null;
+    }
+  }
+
+  void reset({
+    required String email,
+  }) async {}
+
+  // ignore: unused_element
+  void _handleError(Failed failure) {
+    state = ForgetPasswordState.error(failure.errorMessage);
+  }
+}

--- a/lib/views/login/login_view.dart
+++ b/lib/views/login/login_view.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kayla_flutter_ic/di/di.dart';
@@ -6,6 +5,7 @@ import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/usecases/oath/login_use_case.dart';
 import 'package:kayla_flutter_ic/utils/durations.dart';
 import 'package:kayla_flutter_ic/views/common/build_context_ext.dart';
+import 'package:kayla_flutter_ic/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart';
 import 'package:kayla_flutter_ic/views/login/login_form.dart';
 import 'package:kayla_flutter_ic/views/login/login_state.dart';
 import 'package:kayla_flutter_ic/views/login/login_view_model.dart';
@@ -56,33 +56,19 @@ class LoginViewState extends ConsumerState<LoginView>
         child: _linearGradientBlurBackground,
       );
 
-  Stack get _linearGradientBlurBackground => Stack(
-        children: [
-          _backgroundImage,
-          ImageFiltered(
-            imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-            child: ShaderMask(
-              shaderCallback: (rectangle) {
-                return LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.black.withOpacity(0.2),
-                    Colors.black.withOpacity(1),
-                  ],
-                ).createShader(rectangle);
-              },
-              blendMode: BlendMode.overlay,
-              child: _backgroundImage,
-            ),
-          ),
-        ],
-      );
+  Widget get _linearGradientBlurBackground => LinearGradientBlurBackground(
+          image: _backgroundImage,
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Colors.black.withOpacity(0.2),
+            Colors.black.withOpacity(1),
+          ]);
 
   AnimatedPositioned get _animatedLogo => AnimatedPositioned(
         duration: Durations.oneSecond,
         curve: Curves.linear,
-        top: _isLogoAnimated ? -450 : 0.0,
+        top: _isLogoAnimated ? -450 : 0,
         bottom: 0.0,
         left: 0.0,
         right: 0.0,
@@ -134,10 +120,9 @@ class LoginViewState extends ConsumerState<LoginView>
         _animatedLogo,
         Scaffold(
           backgroundColor: Colors.transparent,
-          body: SizedBox(
-            width: MediaQuery.of(context).size.width,
-            height: MediaQuery.of(context).size.height,
+          body: Center(
             child: Container(
+              width: MediaQuery.of(context).size.width,
               padding: const EdgeInsets.symmetric(vertical: 30, horizontal: 24),
               child: _animatedLoginForm,
             ),
@@ -204,13 +189,11 @@ class LoginViewState extends ConsumerState<LoginView>
       );
       state.maybeWhen(
         error: (error) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Please try again. $error.')));
+          context.showSnackBar(message: 'Please try again. $error.');
         },
         success: () async {
           // TODO: - Navigate to other screen
-          ScaffoldMessenger.of(context)
-              .showSnackBar(const SnackBar(content: Text('Login sucess!')));
+          context.showSnackBar(message: 'Login sucess!');
         },
         orElse: () {},
       );


### PR DESCRIPTION
- Close #15

## What happened 👀

The user may forget his/her password after a long time of using the application. To provide the user a method to get back his/her password, the application requires the user to fill registered email.

After the user taps on the `Forgot?` button on the login screen, navigate to the forgot password screen.

In the forgot password screen, show:

- Nimble company logo
- Forgot password instruction
- A text field for inputting registered email
- A `Reset` button

It is recommended to have a format verification for the email input.

## Proof Of Work 📹

<img width=300 src="https://user-images.githubusercontent.com/23162627/218071955-2b03138d-6abe-4bf0-a4b3-870b5fe70762.gif">

