### PR TITLE
[#17] [#42] [Backend] [Integration] As a user, I can see the profile information on home screen and on right sidebar

### DIFF
--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -13,5 +13,5 @@ abstract class ApiService {
   Future<List<UserResponse>> getUsers();
 
   @GET('/api/v1/me')
-  Future<MeResponse> getMe();
+  Future<MeResponse> getMyProfile();
 }

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -13,5 +13,5 @@ abstract class ApiService {
   Future<List<UserResponse>> getUsers();
 
   @GET('/api/v1/me')
-  Future<MeResponse> me();
+  Future<MeResponse> getMe();
 }

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:kayla_flutter_ic/model/response/user_response.dart';
+import 'package:kayla_flutter_ic/api/response/me_response.dart';
 import 'package:retrofit/retrofit.dart';
 
 part 'api_service.g.dart';
@@ -8,7 +8,6 @@ part 'api_service.g.dart';
 abstract class ApiService {
   factory ApiService(Dio dio, {String baseUrl}) = _ApiService;
 
-  // TODO add API endpoint
-  @GET('users')
-  Future<List<UserResponse>> getUsers();
+  @GET('/api/v1/me')
+  Future<MeResponse> me();
 }

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:kayla_flutter_ic/api/response/me_response.dart';
+import 'package:kayla_flutter_ic/model/response/user_response.dart';
 import 'package:retrofit/retrofit.dart';
 
 part 'api_service.g.dart';
@@ -7,6 +8,9 @@ part 'api_service.g.dart';
 @RestApi()
 abstract class ApiService {
   factory ApiService(Dio dio, {String baseUrl}) = _ApiService;
+
+  @GET('users')
+  Future<List<UserResponse>> getUsers();
 
   @GET('/api/v1/me')
   Future<MeResponse> me();

--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -4,7 +4,7 @@ import 'package:kayla_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:kayla_flutter_ic/api/response/me_response.dart';
 
 abstract class UserRepository {
-  Future<MeResponse> me();
+  Future<MeResponse> getMe();
 }
 
 @Singleton(as: UserRepository)
@@ -14,9 +14,9 @@ class UserRepositoryImpl extends UserRepository {
   UserRepositoryImpl(this._apiService);
 
   @override
-  Future<MeResponse> me() async {
+  Future<MeResponse> getMe() async {
     try {
-      return await _apiService.me();
+      return await _apiService.getMe();
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -1,0 +1,24 @@
+import 'package:injectable/injectable.dart';
+import 'package:kayla_flutter_ic/api/api_service.dart';
+import 'package:kayla_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:kayla_flutter_ic/api/response/me_response.dart';
+
+abstract class UserRepository {
+  Future<MeResponse> me();
+}
+
+@Singleton(as: UserRepository)
+class UserRepositoryImpl extends UserRepository {
+  final ApiService _apiService;
+
+  UserRepositoryImpl(this._apiService);
+
+  @override
+  Future<MeResponse> me() async {
+    try {
+      return await _apiService.me();
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+}

--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -4,7 +4,7 @@ import 'package:kayla_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:kayla_flutter_ic/api/response/me_response.dart';
 
 abstract class UserRepository {
-  Future<MeResponse> getMe();
+  Future<MeResponse> getMyProfile();
 }
 
 @Singleton(as: UserRepository)
@@ -14,9 +14,9 @@ class UserRepositoryImpl extends UserRepository {
   UserRepositoryImpl(this._apiService);
 
   @override
-  Future<MeResponse> getMe() async {
+  Future<MeResponse> getMyProfile() async {
     try {
-      return await _apiService.getMe();
+      return await _apiService.getMyProfile();
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/response/me_response.dart
+++ b/lib/api/response/me_response.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:kayla_flutter_ic/api/response/base_response_converter.dart';
+
+part 'me_response.g.dart';
+
+@JsonSerializable()
+class MeResponse {
+  final String id;
+  final String type;
+  final String email;
+  final String avatarUrl;
+
+  MeResponse({
+    required this.id,
+    required this.type,
+    required this.email,
+    required this.avatarUrl,
+  });
+
+  factory MeResponse.fromJson(Map<String, dynamic> json) =>
+      _$MeResponseFromJson(fromJsonApi(json));
+}

--- a/lib/model/profile.dart
+++ b/lib/model/profile.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class Profile extends Equatable {
+  final String id;
+  final String email;
+  final String avatarUrl;
+
+  const Profile({
+    required this.id,
+    required this.email,
+    required this.avatarUrl,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        email,
+        avatarUrl,
+      ];
+}

--- a/lib/usecases/user/get_profile_use_case.dart
+++ b/lib/usecases/user/get_profile_use_case.dart
@@ -15,7 +15,7 @@ class ProfileUseCase extends NoParamsUseCase<Profile> {
   @override
   Future<Result<Profile>> call() async {
     try {
-      final result = await _repository.getMe();
+      final result = await _repository.getMyProfile();
       return Success(Profile(
         id: result.id,
         email: result.email,

--- a/lib/usecases/user/get_profile_use_case.dart
+++ b/lib/usecases/user/get_profile_use_case.dart
@@ -15,7 +15,7 @@ class ProfileUseCase extends NoParamsUseCase<Profile> {
   @override
   Future<Result<Profile>> call() async {
     try {
-      final result = await _repository.me();
+      final result = await _repository.getMe();
       return Success(Profile(
         id: result.id,
         email: result.email,

--- a/lib/usecases/user/get_profile_use_case.dart
+++ b/lib/usecases/user/get_profile_use_case.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'package:injectable/injectable.dart';
+import 'package:kayla_flutter_ic/api/repository/user_repository.dart';
+import 'package:kayla_flutter_ic/model/profile.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+
+@Injectable()
+class ProfileUseCase extends NoParamsUseCase<Profile> {
+  final UserRepository _repository;
+
+  const ProfileUseCase(
+    this._repository,
+  );
+
+  @override
+  Future<Result<Profile>> call() async {
+    try {
+      final result = await _repository.me();
+      return Success(Profile(
+        id: result.id,
+        email: result.email,
+        avatarUrl: result.avatarUrl,
+      ));
+    } catch (exception) {
+      return Failed(UseCaseException(exception));
+    }
+  }
+}

--- a/lib/views/home/home_header.dart
+++ b/lib/views/home/home_header.dart
@@ -4,7 +4,12 @@ import 'package:intl/intl.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 
 class HomeHeader extends StatelessWidget {
-  const HomeHeader({super.key});
+  final String profileImageUrl;
+
+  const HomeHeader({
+    super.key,
+    required this.profileImageUrl,
+  });
 
   String get _dateText {
     final today = DateTime.now();
@@ -21,11 +26,9 @@ class HomeHeader extends StatelessWidget {
         style: Theme.of(context).textTheme.displayLarge,
       );
 
-  // TODO: - Network image
-  Image get _profileImage => Image(
-        image: Assets.images.nimbleLogo.image().image,
-        fit: BoxFit.cover,
-        alignment: Alignment.center,
+  FadeInImage get _profileImage => FadeInImage.assetNetwork(
+        placeholder: Assets.images.nimbleLogo.path,
+        image: profileImageUrl,
       );
 
   Widget _profilePictureWidget(BuildContext context) => GestureDetector(
@@ -35,6 +38,8 @@ class HomeHeader extends StatelessWidget {
           context.pop();
         },
         child: Container(
+          width: 50,
+          height: 50,
           padding: const EdgeInsets.symmetric(vertical: 10),
           child: CircleAvatar(
             backgroundColor: Colors.white,

--- a/lib/views/home/home_state.dart
+++ b/lib/views/home/home_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_state.freezed.dart';
+
+@freezed
+class HomeState with _$HomeState {
+  const factory HomeState.init() = _Init;
+
+  const factory HomeState.loading() = _Loading;
+
+  const factory HomeState.error(String? error) = _Error;
+
+  const factory HomeState.success() = _Success;
+}

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kayla_flutter_ic/di/di.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/usecases/user/get_profile_use_case.dart';
-import 'package:kayla_flutter_ic/views/common/build_context_ext.dart';
+import 'package:kayla_flutter_ic/utils/build_context_ext.dart';
 import 'package:kayla_flutter_ic/views/home/home_header.dart';
 import 'package:kayla_flutter_ic/views/home/home_state.dart';
 import 'package:kayla_flutter_ic/views/home/home_view_model.dart';

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/model/profile.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+import 'package:kayla_flutter_ic/usecases/user/get_profile_use_case.dart';
+import 'package:kayla_flutter_ic/views/home/home_state.dart';
+import 'package:kayla_flutter_ic/views/home/home_view.dart';
+
+final profileImageUrlStream = StreamProvider.autoDispose<String>((ref) =>
+    ref.watch(homeViewModelProvider.notifier).profileImageUrlStream.stream);
+
+class HomeViewModel extends StateNotifier<HomeState> {
+  final StreamController<String> profileImageUrlStream = StreamController();
+
+  final ProfileUseCase _profileUseCase;
+
+  HomeViewModel(this._profileUseCase) : super(const HomeState.init());
+
+  Future<void> fetchProfile() async {
+    final result = await _profileUseCase.call();
+    if (result is Success<Profile>) {
+      profileImageUrlStream.add(result.value.avatarUrl);
+    } else {
+      _handleError(result as Failed);
+    }
+  }
+
+  void _handleError(Failed failure) {
+    state = HomeState.error(failure.errorMessage);
+  }
+}


### PR DESCRIPTION
- Close #17 #42

## What happened 👀

As a user, I can see the profile information on the home screen and on the right sidebar.

Get the user's profile after logging in success. Follow the [API document for /api/v1/me](https://documenter.getpostman.com/view/11835486/T1LJjTqj#d85908f5-b07b-4ae7-9e71-f58c55f05f01).

If the response returns with success, bind the profile email and profile image URL into:

- The profile image on the home screen

If the response returns with failure, keep those information blank.

## Insight 📝

Describe in detail why this solution is the most appropriate, which solution you tried but did not go with, and how to test the changes. References to relevant documentation are welcome as well.

Inside the `HomeViewModel`, I created a `StreamController<String>` to stream the profile image URL. In the `HomeView`, I implemented loading the profile image by two ways:

- The first way is using the `StreamBuilder` widget inside the `Consumer` widget in the `HomeView`. However, this approach is not neat. So I adopted the second way.
  - Code of the 1st way:
 
```dart
// home_view_model.dart
class HomeViewModel extends StateNotifier<HomeState> {
  final StreamController<String> profileImageUrlStream = StreamController();
  ...
  Future<void> fetchProfile() async {
    final result = await _profileUseCase.call();
    if (result is Success<Profile>) {
      profileImageUrlStream.add(result.value.avatarUrl);
    } ...
  }
}

// home_view.dart
class HomeViewState extends ConsumerState<HomeView> {
   ...
   Widget get _homeHeader => Consumer(
        builder: (_, ref, __) {
          return StreamBuilder(
            initialData: '',
            stream: ref
                .watch(homeViewModelProvider.notifier)
                .profileImageUrlStream
                .stream,
            builder: (_, snapshot) =>
                HomeHeader(profileImageUrl: snapshot.data as String),
          );
   ...
}
```

- The second way is defining a global`StreamProvider<String>` to broadcast the profile image URL based on the `StreamController<String>` inside the `HomeViewModel`. 
  - Code of the 2nd way:
 
```dart
// home_view_model.dart
final profileImageUrlStream = StreamProvider.autoDispose<String>((ref) =>
    ref.watch(homeViewModelProvider.notifier).profileImageUrlStream.stream);
class HomeViewModel extends StateNotifier<HomeState> {
  final StreamController<String> profileImageUrlStream = StreamController();
  ...
  Future<void> fetchProfile() async {
    final result = await _profileUseCase.call();
    if (result is Success<Profile>) {
      profileImageUrlStream.add(result.value.avatarUrl);
    } ...
  }
}

// home_view.dart
class HomeViewState extends ConsumerState<HomeView> {
   ...
   Widget get _homeHeader => Consumer(
        builder: (_, ref, __) {
          return HomeHeader(
              profileImageUrl: ref.watch(profileImageUrlStream).value ?? '');
        },
      );
   ...
}
```

## Proof Of Work 📹

<img width=300 src="https://user-images.githubusercontent.com/23162627/218706838-44a93160-f163-41b7-b7ab-0596de6bc14b.gif">
