### PR TITLE
[#18] [#20] [UI] [Integration] As a user, I can see the available surveys on the home screen

### DIFF
--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -31,11 +31,21 @@ class HomeViewState extends ConsumerState<HomeView> {
   final _surveyItemController = PageController();
   final _surveyIndex = ValueNotifier<int>(0);
 
-  // TODO: - Network image
-  Image get _backgroundImage => Image(
-        image: Assets.images.nimbleBackground.image().image,
-        fit: BoxFit.cover,
-        alignment: Alignment.center,
+  Widget get _background => SizedBox(
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height,
+        child: Consumer(builder: (_, ref, __) {
+          final index = ref.watch(focusedItemIndexStream).value ?? 0;
+          final surveyList = ref.watch(surveysStream).value ?? [];
+          return surveyList.isEmpty
+              ? Image(image: Assets.images.nimbleBackground.image().image)
+              : FadeInImage.assetNetwork(
+                  placeholder: Assets.images.nimbleBackground.path,
+                  image: surveyList[index].coverImageUrl,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.center,
+                );
+        }),
       );
 
   Widget get _homeHeader => Consumer(
@@ -46,7 +56,7 @@ class HomeViewState extends ConsumerState<HomeView> {
       );
 
   Widget get _surveySection => Consumer(builder: (_, ref, __) {
-        final surveyList = ref.watch(surveyListStream).value ?? [];
+        final surveyList = ref.watch(surveysStream).value ?? [];
         return Column(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -112,14 +122,12 @@ class HomeViewState extends ConsumerState<HomeView> {
     _setupStateListener();
     return WillPopScope(
       child: Scaffold(
-        body: Container(
-          decoration: BoxDecoration(
-            image: DecorationImage(
-              image: _backgroundImage.image,
-              fit: BoxFit.cover,
-            ),
-          ),
-          child: _body,
+        body: Stack(
+          children: [
+            _background,
+            Container(color: Colors.black38),
+            _body,
+          ],
         ),
         floatingActionButton: takeSurveyButton,
         floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
@@ -139,6 +147,11 @@ class HomeViewState extends ConsumerState<HomeView> {
         },
         orElse: () {},
       );
+    });
+    _surveyIndex.addListener(() {
+      ref
+          .read(homeViewModelProvider.notifier)
+          .changeFocusedItem(index: _surveyIndex.value);
     });
   }
 

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -9,6 +9,8 @@ import 'package:kayla_flutter_ic/views/home/home_header.dart';
 import 'package:kayla_flutter_ic/views/home/home_state.dart';
 import 'package:kayla_flutter_ic/views/home/home_view_model.dart';
 import 'package:kayla_flutter_ic/views/home/skeleton_loading/home_skeleton_loading.dart';
+import 'package:kayla_flutter_ic/views/home/survey_section/survey_list.dart';
+import 'package:kayla_flutter_ic/views/home/survey_section/survey_page_indicator.dart';
 
 final homeViewModelProvider =
     StateNotifierProvider.autoDispose<HomeViewModel, HomeState>(
@@ -26,6 +28,9 @@ class HomeView extends ConsumerStatefulWidget {
 }
 
 class HomeViewState extends ConsumerState<HomeView> {
+  final _surveyItemController = PageController();
+  final _surveyIndex = ValueNotifier<int>(0);
+
   // TODO: - Network image
   Image get _backgroundImage => Image(
         image: Assets.images.nimbleBackground.image().image,
@@ -40,6 +45,39 @@ class HomeViewState extends ConsumerState<HomeView> {
         },
       );
 
+  Widget get _surveySection => Consumer(builder: (_, ref, __) {
+        final surveyList = ref.watch(surveyListStream).value ?? [];
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SurveyPageIndicator(
+              controller: _surveyItemController,
+              count: surveyList.length,
+            ),
+            SingleChildScrollView(
+              child: SizedBox(
+                height: 160,
+                child: SurveyList(
+                  surveyList: surveyList,
+                  itemController: _surveyItemController,
+                  onItemChange: _surveyIndex,
+                ),
+              ),
+            ),
+          ],
+        );
+      });
+
+  Widget get _mainBody => Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _homeHeader,
+          _surveySection,
+        ],
+      );
+
   Widget get takeSurveyButton => FloatingActionButton(
         foregroundColor: Colors.black,
         backgroundColor: Colors.white,
@@ -51,7 +89,7 @@ class HomeViewState extends ConsumerState<HomeView> {
         builder: (_, ref, __) {
           final surveys = ref.watch(surveysStream).value ?? [];
           return surveys.isNotEmpty
-              ? SafeArea(child: _homeHeader)
+              ? SafeArea(child: _mainBody)
               : const SafeArea(child: HomeSkeletonLoading());
         },
       );
@@ -61,6 +99,12 @@ class HomeViewState extends ConsumerState<HomeView> {
     super.initState();
     _fetchProfile();
     _fetchSurvey();
+  }
+
+  @override
+  void dispose() {
+    _surveyIndex.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -40,6 +40,13 @@ class HomeViewState extends ConsumerState<HomeView> {
         },
       );
 
+  Widget get takeSurveyButton => FloatingActionButton(
+        foregroundColor: Colors.black,
+        backgroundColor: Colors.white,
+        child: const Icon(Icons.navigate_next),
+        onPressed: () => _takeSurvey(),
+      );
+
   Widget get _body => Consumer(
         builder: (_, ref, __) {
           final surveys = ref.watch(surveysStream).value ?? [];
@@ -70,6 +77,8 @@ class HomeViewState extends ConsumerState<HomeView> {
           ),
           child: _body,
         ),
+        floatingActionButton: takeSurveyButton,
+        floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
       ),
       onWillPop: () async => false,
     );
@@ -95,5 +104,9 @@ class HomeViewState extends ConsumerState<HomeView> {
 
   void _fetchSurvey() {
     ref.read(homeViewModelProvider.notifier).fetchSurveys();
+  }
+
+  void _takeSurvey() {
+    // TODO: - Take survey
   }
 }

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -13,8 +13,8 @@ import 'package:kayla_flutter_ic/views/home/home_view.dart';
 final profileImageUrlStream = StreamProvider.autoDispose<String>((ref) =>
     ref.watch(homeViewModelProvider.notifier)._profileImageUrlStream.stream);
 
-final surveysStream = StreamProvider.autoDispose<List<Survey>>((ref) =>
-    ref.watch(homeViewModelProvider.notifier)._surveysStream.stream);
+final surveysStream = StreamProvider.autoDispose<List<Survey>>(
+    (ref) => ref.watch(homeViewModelProvider.notifier)._surveysStream.stream);
 
 final focusedItemIndexStream = StreamProvider.autoDispose<int>((ref) =>
     ref.watch(homeViewModelProvider.notifier)._focusedItemIndexStream.stream);

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kayla_flutter_ic/api/response/surveys_response.dart';
 import 'package:kayla_flutter_ic/model/profile.dart';
+import 'package:kayla_flutter_ic/model/survey.dart';
 import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
 import 'package:kayla_flutter_ic/usecases/survey/get_surveys_params.dart';
 import 'package:kayla_flutter_ic/usecases/survey/get_surveys_use_case.dart';
@@ -12,12 +13,12 @@ import 'package:kayla_flutter_ic/views/home/home_view.dart';
 final profileImageUrlStream = StreamProvider.autoDispose<String>((ref) =>
     ref.watch(homeViewModelProvider.notifier)._profileImageUrlStream.stream);
 
-final surveysStream = StreamProvider.autoDispose<List<String>>(
-    (ref) => ref.watch(homeViewModelProvider.notifier)._surveysStream.stream);
+final surveysStream = StreamProvider.autoDispose<List<Survey>>((ref) =>
+    ref.watch(homeViewModelProvider.notifier)._surveysStream.stream);
 
 class HomeViewModel extends StateNotifier<HomeState> {
   final StreamController<String> _profileImageUrlStream = StreamController();
-  final StreamController<List<String>> _surveysStream = StreamController();
+  final StreamController<List<Survey>> _surveysStream = StreamController();
 
   final GetProfileUseCase _getProfileUseCase;
   final GetSurveysUseCase _getSurveysUseCase;

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -16,9 +16,13 @@ final profileImageUrlStream = StreamProvider.autoDispose<String>((ref) =>
 final surveysStream = StreamProvider.autoDispose<List<Survey>>((ref) =>
     ref.watch(homeViewModelProvider.notifier)._surveysStream.stream);
 
+final focusedItemIndexStream = StreamProvider.autoDispose<int>((ref) =>
+    ref.watch(homeViewModelProvider.notifier)._focusedItemIndexStream.stream);
+
 class HomeViewModel extends StateNotifier<HomeState> {
   final StreamController<String> _profileImageUrlStream = StreamController();
   final StreamController<List<Survey>> _surveysStream = StreamController();
+  final StreamController<int> _focusedItemIndexStream = StreamController();
 
   final GetProfileUseCase _getProfileUseCase;
   final GetSurveysUseCase _getSurveysUseCase;
@@ -43,8 +47,7 @@ class HomeViewModel extends StateNotifier<HomeState> {
       pageSize: 5,
     ));
     if (result is Success<SurveysResponse>) {
-      // TODO: - Stream the survey list instead
-      _surveysStream.add(result.value.data.map((e) => e.title).toList());
+      _surveysStream.add(result.value.data.map((e) => e.toSurvey()).toList());
     } else {
       _handleError(result as Failed);
     }
@@ -52,5 +55,9 @@ class HomeViewModel extends StateNotifier<HomeState> {
 
   void _handleError(Failed failure) {
     state = HomeState.error(failure.errorMessage);
+  }
+
+  void changeFocusedItem({required int index}) {
+    _focusedItemIndexStream.add(index);
   }
 }

--- a/lib/views/home/skeleton_loading/home_skeleton_loading.dart
+++ b/lib/views/home/skeleton_loading/home_skeleton_loading.dart
@@ -46,22 +46,25 @@ class HomeSkeletonLoading extends StatelessWidget {
         ),
       );
 
-  Widget _buildBottomSkeleton(BuildContext context) => Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.max,
-        children: [
-          const TextPlaceholder(
-            type: TextPlaceholderType.oneLine,
-            width: 40,
-          ),
-          const SizedBox(height: 16.0),
-          TextPlaceholder(
-              type: TextPlaceholderType.twoLines,
-              width: MediaQuery.of(context).size.width - 150),
-          const SizedBox(height: 16.0),
-          TextPlaceholder(
-              type: TextPlaceholderType.twoLines,
-              width: MediaQuery.of(context).size.width - 40),
-        ],
+  Widget _buildBottomSkeleton(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 40),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            const TextPlaceholder(
+              type: TextPlaceholderType.oneLine,
+              width: 40,
+            ),
+            const SizedBox(height: 16.0),
+            TextPlaceholder(
+                type: TextPlaceholderType.twoLines,
+                width: MediaQuery.of(context).size.width - 150),
+            const SizedBox(height: 16.0),
+            TextPlaceholder(
+                type: TextPlaceholderType.twoLines,
+                width: MediaQuery.of(context).size.width - 40),
+          ],
+        ),
       );
 }

--- a/lib/views/home/survey_section/survey_cell.dart
+++ b/lib/views/home/survey_section/survey_cell.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:kayla_flutter_ic/model/survey.dart';
+
+class SurveyCell extends StatelessWidget {
+  final Survey _survey;
+
+  const SurveyCell(this._survey, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width,
+      padding: const EdgeInsets.only(
+        top: 20,
+        left: 20,
+        right: 90,
+        bottom: 20,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _survey.title,
+            style: Theme.of(context).textTheme.displayMedium,
+            maxLines: 2,
+          ),
+          const SizedBox(
+            height: 16,
+          ),
+          Text(
+            _survey.description,
+            style: Theme.of(context).textTheme.bodyMedium,
+            maxLines: 2,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/home/survey_section/survey_list.dart
+++ b/lib/views/home/survey_section/survey_list.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:kayla_flutter_ic/model/survey.dart';
+import 'package:kayla_flutter_ic/views/home/survey_section/survey_cell.dart';
+
+class SurveyList extends StatelessWidget {
+  final List<Survey> surveyList;
+  final PageController itemController;
+  final ValueNotifier<int> onItemChange;
+
+  const SurveyList({
+    super.key,
+    required this.surveyList,
+    required this.itemController,
+    required this.onItemChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+      scrollDirection: Axis.horizontal,
+      controller: itemController,
+      onPageChanged: (index) => onItemChange.value = index,
+      itemCount: surveyList.length,
+      itemBuilder: (context, index) => SurveyCell(surveyList[index]),
+    );
+  }
+}

--- a/lib/views/home/survey_section/survey_page_indicator.dart
+++ b/lib/views/home/survey_section/survey_page_indicator.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class SurveyPageIndicator extends StatelessWidget {
+  final PageController controller;
+  final int count;
+
+  const SurveyPageIndicator({
+    super.key,
+    required this.controller,
+    required this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: SmoothPageIndicator(
+        controller: controller,
+        count: count,
+        effect: const ColorTransitionEffect(
+          dotWidth: 8,
+          dotHeight: 8,
+          radius: 8,
+          spacing: 10,
+          dotColor: Colors.white30,
+          activeDotColor: Colors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -671,6 +671,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  smooth_page_indicator:
+    dependency: "direct main"
+    description:
+      name: smooth_page_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   flutter_secure_storage: ^5.0.2
   email_validator: ^2.1.16
   shimmer: ^2.0.0
+  smooth_page_indicator: ^1.0.1
 
 dev_dependencies:
   build_runner: ^2.1.11


### PR DESCRIPTION
- Close #18 #20

## What happened 👀

The user can see a list of the surveys which have not been finished by the users on the home screen. The user can only see one item on the list at a time.

Show a series of small indicator dots representing the available item in the order they were opened. A solid dot denotes the current page. Users cannot tap on a specific dot to go to a specific page. 

Show a horizontal collection view page. Each page contains the title and description of the survey.

The screen's background is according to the cover image URL of the current survey onscreen.

The user can navigate to the next/previous item by swiping the page to one side.

A circle button to go to take the survey.

## Insight 📝

N/A

## Proof Of Work 📹

<img width=300 src="https://user-images.githubusercontent.com/23162627/219571115-0e196cd7-1deb-4157-bf78-20cd726303c4.gif">