### PR TITLE
[Chore] Refactor app router

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,14 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:go_router/go_router.dart';
-import 'package:kayla_flutter_ic/utils/route_paths.dart';
+import 'package:kayla_flutter_ic/utils/app_router.dart';
 import 'package:kayla_flutter_ic/utils/themes.dart';
-import 'package:kayla_flutter_ic/views/forget_password/forget_password_view.dart';
 import 'package:kayla_flutter_ic/di/di.dart';
-import 'package:kayla_flutter_ic/views/home/home_view.dart';
-import 'package:kayla_flutter_ic/views/login/login_view.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,42 +16,23 @@ void main() async {
   runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
 
-  GoRouter get _router => GoRouter(
-        routes: <GoRoute>[
-          _loginGoRoute,
-          _homeGoRoute,
-        ],
-      );
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
 
-  GoRoute get _loginGoRoute => GoRoute(
-        path: RoutePath.login.path,
-        builder: (BuildContext context, GoRouterState state) =>
-            const LoginView(),
-        routes: [
-          GoRoute(
-            path: RoutePath.forgetPassword.path,
-            builder: (BuildContext context, GoRouterState state) =>
-                const ForgetPasswordView(),
-          ),
-        ],
-      );
-
-  GoRoute get _homeGoRoute => GoRoute(
-        path: RoutePath.home.path,
-        builder: (BuildContext context, GoRouterState state) =>
-            const HomeView(),
-        routes: const [],
-      );
+class _MyAppState extends State<MyApp> {
+  late GoRouter _router;
 
   @override
   Widget build(BuildContext context) {
+    _router = AppRouter(getIt.get<SecureStorage>()).router;
     return MaterialApp.router(
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        brightness: Brightness.light,
+        brightness: Brightness.dark,
         fontFamily: Assets.fonts.neuzeit,
         appBarTheme: Themes.appBarTheme,
         textTheme: Themes.textTheme,

--- a/lib/usecases/oath/logout_use_case.dart
+++ b/lib/usecases/oath/logout_use_case.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+import 'package:injectable/injectable.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
+import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+
+@Injectable()
+class LogoutUseCase extends NoParamsUseCase<String> {
+  final SecureStorage _secureStorage;
+
+  const LogoutUseCase(
+    this._secureStorage,
+  );
+
+  @override
+  Future<Result<String>> call() async {
+    _resetTokens();
+    return Success('Log out!');
+  }
+
+  Future<Result<void>> _resetTokens() async {
+    await _secureStorage.clearAllStorage();
+    return Success(null);
+  }
+}

--- a/lib/utils/app_bar_ext.dart
+++ b/lib/utils/app_bar_ext.dart
@@ -1,9 +1,21 @@
+// ignore_for_file: avoid_init_to_null
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 extension AppBarExt on AppBar {
-  static final AppBar appBarWithBackButton = AppBar(
-    leading: const BackButton(),
-    backgroundColor: Colors.transparent,
-    shadowColor: Colors.transparent,
-  );
+  static AppBar appBarWithBackButton({
+    required BuildContext context,
+    void Function()? onPressed = null,
+  }) =>
+      AppBar(
+        leading: BackButton(onPressed: () {
+          if (onPressed != null) {
+            onPressed();
+          } else if (context.canPop()) {
+            context.pop();
+          }
+        }),
+        backgroundColor: Colors.transparent,
+        shadowColor: Colors.transparent,
+      );
 }

--- a/lib/utils/app_bar_ext.dart
+++ b/lib/utils/app_bar_ext.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+extension AppBarExt on AppBar {
+  static final AppBar appBarWithBackButton = AppBar(
+    leading: const BackButton(),
+    backgroundColor: Colors.transparent,
+    shadowColor: Colors.transparent,
+  );
+}

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -1,0 +1,54 @@
+import 'package:go_router/go_router.dart';
+import 'package:kayla_flutter_ic/api/storage/secure_storage.dart';
+import 'package:kayla_flutter_ic/utils/route_paths.dart';
+import 'package:kayla_flutter_ic/views/forget_password/forget_password_view.dart';
+import 'package:kayla_flutter_ic/views/home/home_view.dart';
+import 'package:kayla_flutter_ic/views/login/login_view.dart';
+import 'package:kayla_flutter_ic/views/survey_detail/survey_detail_view.dart';
+
+class AppRouter {
+  final SecureStorage _secureStorage;
+
+  AppRouter(this._secureStorage);
+
+  GoRouter get router => GoRouter(
+        initialLocation: RoutePath.home.path,
+        routes: <GoRoute>[
+          GoRoute(
+            path: RoutePath.home.screen,
+            name: RoutePath.home.name,
+            builder: (context, state) => const HomeView(),
+            routes: [
+              GoRoute(
+                path: RoutePath.surveyDetail.screenWithPathParams,
+                name: RoutePath.surveyDetail.name,
+                builder: (context, state) => SurveyDetailView(
+                  surveyId:
+                      state.params[RoutePath.surveyDetail.pathParam] ?? '',
+                ),
+              ),
+              GoRoute(
+                path: RoutePath.forgetPassword.screen,
+                name: RoutePath.forgetPassword.name,
+                builder: (context, state) => const ForgetPasswordView(),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: RoutePath.login.screen,
+            name: RoutePath.login.name,
+            builder: (context, state) => const LoginView(),
+          ),
+        ],
+        redirect: (context, state) async {
+          final subLocation = state.subloc;
+          final isLogin = await _secureStorage.id != null;
+          if (!isLogin &&
+              subLocation != RoutePath.forgetPassword.path &&
+              subLocation != RoutePath.login.path) {
+            return RoutePath.login.path;
+          }
+          return null;
+        },
+      );
+}

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -27,17 +27,17 @@ class AppRouter {
                       state.params[RoutePath.surveyDetail.pathParam] ?? '',
                 ),
               ),
-              GoRoute(
-                path: RoutePath.forgetPassword.screen,
-                name: RoutePath.forgetPassword.name,
-                builder: (context, state) => const ForgetPasswordView(),
-              ),
             ],
           ),
           GoRoute(
             path: RoutePath.login.screen,
             name: RoutePath.login.name,
             builder: (context, state) => const LoginView(),
+          ),
+          GoRoute(
+            path: RoutePath.forgetPassword.screen,
+            name: RoutePath.forgetPassword.name,
+            builder: (context, state) => const ForgetPasswordView(),
           ),
         ],
         redirect: (context, state) async {

--- a/lib/utils/route_paths.dart
+++ b/lib/utils/route_paths.dart
@@ -11,6 +11,7 @@ enum RoutePath {
     switch (this) {
       case RoutePath.home:
       case RoutePath.login:
+      case RoutePath.forgetPassword:
         return path;
       default:
         return path.replaceRange(0, 1, '');

--- a/lib/utils/route_paths.dart
+++ b/lib/utils/route_paths.dart
@@ -1,19 +1,45 @@
 enum RoutePath {
-  login('/'),
-  forgetPassword('forget-password'),
-  home('/home');
+  login('/login'),
+  home('/'),
+  forgetPassword('/forget-password'),
+  surveyDetail('/surveys');
 
   const RoutePath(this.path);
   final String path;
 
   String get screen {
     switch (this) {
+      case RoutePath.home:
       case RoutePath.login:
         return path;
-      case RoutePath.home:
-        return path;
-      case RoutePath.forgetPassword:
-        return '/$path';
+      default:
+        return path.replaceRange(0, 1, '');
     }
+  }
+
+  String get pathParam {
+    switch (this) {
+      case RoutePath.surveyDetail:
+        return 'surveyId';
+      default:
+        return '';
+    }
+  }
+
+  String get name {
+    switch (this) {
+      case RoutePath.login:
+        return "LOGIN";
+      case RoutePath.home:
+        return "HOME";
+      case RoutePath.forgetPassword:
+        return "FORGET_PASSWORD";
+      case RoutePath.surveyDetail:
+        return "SURVEY_DETAIL";
+    }
+  }
+
+  String get screenWithPathParams {
+    return pathParam.isEmpty ? screen : '$screen/:$pathParam';
   }
 }

--- a/lib/views/forget_password/forget_password_view.dart
+++ b/lib/views/forget_password/forget_password_view.dart
@@ -29,7 +29,7 @@ class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
     with TickerProviderStateMixin {
   AppBar get _appBar => AppBarExt.appBarWithBackButton(
         context: context,
-        onPressed: () => context.go(RoutePath.login.screen),
+        onPressed: () => context.goNamed(RoutePath.login.name),
       );
 
   Widget get _background => SizedBox(

--- a/lib/views/forget_password/forget_password_view.dart
+++ b/lib/views/forget_password/forget_password_view.dart
@@ -4,6 +4,7 @@ import 'package:kayla_flutter_ic/di/di.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/usecases/oath/forget_password_use_case.dart';
 import 'package:kayla_flutter_ic/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart';
+import 'package:kayla_flutter_ic/utils/app_bar_ext.dart';
 import 'package:kayla_flutter_ic/utils/build_context_ext.dart';
 import 'package:kayla_flutter_ic/views/common/top_snack_bar/top_snack_bar.dart';
 import 'package:kayla_flutter_ic/views/forget_password/forget_password_form.dart';
@@ -24,11 +25,7 @@ class ForgetPasswordView extends ConsumerStatefulWidget {
 
 class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
     with TickerProviderStateMixin {
-  AppBar get _appBar => AppBar(
-        leading: const BackButton(),
-        backgroundColor: Colors.transparent,
-        shadowColor: Colors.transparent,
-      );
+  AppBar get _appBar => AppBarExt.appBarWithBackButton;
 
   Widget get _background => SizedBox(
         width: MediaQuery.of(context).size.width,

--- a/lib/views/forget_password/forget_password_view.dart
+++ b/lib/views/forget_password/forget_password_view.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kayla_flutter_ic/di/di.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/usecases/oath/forget_password_use_case.dart';
+import 'package:kayla_flutter_ic/utils/route_paths.dart';
 import 'package:kayla_flutter_ic/views/common/linear_gradient_blur_background/linear_gradient_blur_background.dart';
 import 'package:kayla_flutter_ic/utils/app_bar_ext.dart';
 import 'package:kayla_flutter_ic/utils/build_context_ext.dart';
@@ -25,7 +27,10 @@ class ForgetPasswordView extends ConsumerStatefulWidget {
 
 class ForgetPasswordViewState extends ConsumerState<ForgetPasswordView>
     with TickerProviderStateMixin {
-  AppBar get _appBar => AppBarExt.appBarWithBackButton;
+  AppBar get _appBar => AppBarExt.appBarWithBackButton(
+        context: context,
+        onPressed: () => context.go(RoutePath.login.screen),
+      );
 
   Widget get _background => SizedBox(
         width: MediaQuery.of(context).size.width,

--- a/lib/views/home/home_header.dart
+++ b/lib/views/home/home_header.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
+import 'package:kayla_flutter_ic/utils/route_paths.dart';
+import 'package:kayla_flutter_ic/views/home/home_view.dart';
 
 class HomeHeader extends StatelessWidget {
   final String profileImageUrl;
@@ -30,20 +34,24 @@ class HomeHeader extends StatelessWidget {
         image: profileImageUrl,
       );
 
-  Widget _profilePictureWidget(BuildContext context) => GestureDetector(
-        onTap: () {
-          // TODO: - Show the side bar to log out
-          // cannot pop as root is Home screen
+  Widget _profilePictureWidget(BuildContext context) => Consumer(
+        builder: (_, ref, __) {
+          return GestureDetector(
+            onTap: () {
+              ref.read(homeViewModelProvider.notifier).logOut();
+              context.go(RoutePath.login.path);
+            },
+            child: Container(
+              width: 50,
+              height: 50,
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: CircleAvatar(
+                backgroundColor: Colors.white,
+                backgroundImage: _profileImage.image,
+              ),
+            ),
+          );
         },
-        child: Container(
-          width: 50,
-          height: 50,
-          padding: const EdgeInsets.symmetric(vertical: 10),
-          child: CircleAvatar(
-            backgroundColor: Colors.white,
-            backgroundImage: _profileImage.image,
-          ),
-        ),
       );
 
   @override

--- a/lib/views/home/home_header.dart
+++ b/lib/views/home/home_header.dart
@@ -39,7 +39,7 @@ class HomeHeader extends StatelessWidget {
           return GestureDetector(
             onTap: () {
               ref.read(homeViewModelProvider.notifier).logOut();
-              context.go(RoutePath.login.path);
+              context.goNamed(RoutePath.login.name);
             },
             child: Container(
               width: 50,

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -182,8 +182,6 @@ class HomeViewState extends ConsumerState<HomeView> {
   void _takeSurvey() {
     Map<String, String> params = <String, String>{};
     params[RoutePath.surveyDetail.pathParam] = _surveyIndex.value.toString();
-    final location =
-        context.namedLocation(RoutePath.surveyDetail.name, params: params);
-    context.push(location);
+    context.pushNamed(RoutePath.surveyDetail.name, params: params);
   }
 }

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -61,13 +61,16 @@ class HomeViewState extends ConsumerState<HomeView> {
         },
       );
 
-  Widget _surveyList(List<Survey> surveys) => SurveyList(
-        refreshStyle: RefreshStyle.pullDownToRefresh,
-        surveys: surveys,
-        itemController: _surveyItemController,
-        onItemChange: _surveyIndex,
-        onRefresh: () => _fetchSurveys(isRefresh: true),
-        onLoadMore: () => _fetchSurveys(isRefresh: false),
+  Widget _surveyList(List<Survey> surveys) => Container(
+        margin: const EdgeInsets.only(top: 120),
+        child: SurveyList(
+          refreshStyle: RefreshStyle.pullDownToRefresh,
+          surveys: surveys,
+          itemController: _surveyItemController,
+          onItemChange: _surveyIndex,
+          onRefresh: () => _fetchSurveys(isRefresh: true),
+          onLoadMore: () => _fetchSurveys(isRefresh: false),
+        ),
       );
 
   Widget _pageIndicatorSection(int length) => Column(
@@ -177,6 +180,10 @@ class HomeViewState extends ConsumerState<HomeView> {
   }
 
   void _takeSurvey() {
-    context.push(RoutePath.surveyDetail.path);
+    Map<String, String> params = <String, String>{};
+    params[RoutePath.surveyDetail.pathParam] = _surveyIndex.value.toString();
+    final location =
+        context.namedLocation(RoutePath.surveyDetail.name, params: params);
+    context.push(location);
   }
 }

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kayla_flutter_ic/di/di.dart';
 import 'package:kayla_flutter_ic/gen/assets.gen.dart';
 import 'package:kayla_flutter_ic/model/survey.dart';
+import 'package:kayla_flutter_ic/usecases/oath/logout_use_case.dart';
 import 'package:kayla_flutter_ic/usecases/survey/get_surveys_use_case.dart';
 import 'package:kayla_flutter_ic/usecases/user/get_profile_use_case.dart';
 import 'package:kayla_flutter_ic/utils/build_context_ext.dart';
 import 'package:kayla_flutter_ic/utils/durations.dart';
+import 'package:kayla_flutter_ic/utils/route_paths.dart';
 import 'package:kayla_flutter_ic/views/home/home_header.dart';
 import 'package:kayla_flutter_ic/views/home/home_state.dart';
 import 'package:kayla_flutter_ic/views/home/home_view_model.dart';
@@ -17,8 +20,9 @@ import 'package:kayla_flutter_ic/views/home/survey_section/survey_page_indicator
 final homeViewModelProvider =
     StateNotifierProvider.autoDispose<HomeViewModel, HomeState>(
   (_) => HomeViewModel(
-    getIt.get<GetProfileUseCase>(),
-    getIt.get<GetSurveysUseCase>(),
+    logoutUseCase: getIt.get<LogoutUseCase>(),
+    getProfileUseCase: getIt.get<GetProfileUseCase>(),
+    getSurveysUseCase: getIt.get<GetSurveysUseCase>(),
   ),
 );
 
@@ -100,7 +104,7 @@ class HomeViewState extends ConsumerState<HomeView> {
         },
       );
 
-  Widget get takeSurveyButton => FloatingActionButton(
+  Widget get _takeSurveyButton => FloatingActionButton(
         foregroundColor: Colors.black,
         backgroundColor: Colors.white,
         child: const Icon(Icons.navigate_next),
@@ -132,19 +136,16 @@ class HomeViewState extends ConsumerState<HomeView> {
   @override
   Widget build(BuildContext context) {
     _setupStateListener();
-    return WillPopScope(
-      child: Scaffold(
-        body: Stack(
-          children: [
-            _background,
-            Container(color: Colors.black38),
-            _body,
-          ],
-        ),
-        floatingActionButton: takeSurveyButton,
-        floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
+    return Scaffold(
+      body: Stack(
+        children: [
+          _background,
+          Container(color: Colors.black38),
+          _body,
+        ],
       ),
-      onWillPop: () async => false,
+      floatingActionButton: _takeSurveyButton,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
     );
   }
 
@@ -176,7 +177,6 @@ class HomeViewState extends ConsumerState<HomeView> {
   }
 
   void _takeSurvey() {
-    // ignore: avoid_print
-    print(_surveyIndex.value);
+    context.push(RoutePath.surveyDetail.path);
   }
 }

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -4,6 +4,7 @@ import 'package:kayla_flutter_ic/api/response/surveys_response.dart';
 import 'package:kayla_flutter_ic/model/profile.dart';
 import 'package:kayla_flutter_ic/model/survey.dart';
 import 'package:kayla_flutter_ic/usecases/base/base_use_case.dart';
+import 'package:kayla_flutter_ic/usecases/oath/logout_use_case.dart';
 import 'package:kayla_flutter_ic/usecases/survey/get_surveys_params.dart';
 import 'package:kayla_flutter_ic/usecases/survey/get_surveys_use_case.dart';
 import 'package:kayla_flutter_ic/usecases/user/get_profile_use_case.dart';
@@ -28,16 +29,18 @@ class HomeViewModel extends StateNotifier<HomeState> {
   int _page = 1;
   bool _isEnded = false;
 
-  final GetProfileUseCase _getProfileUseCase;
-  final GetSurveysUseCase _getSurveysUseCase;
+  final LogoutUseCase logoutUseCase;
+  final GetProfileUseCase getProfileUseCase;
+  final GetSurveysUseCase getSurveysUseCase;
 
-  HomeViewModel(
-    this._getProfileUseCase,
-    this._getSurveysUseCase,
-  ) : super(const HomeState.init());
+  HomeViewModel({
+    required this.logoutUseCase,
+    required this.getProfileUseCase,
+    required this.getSurveysUseCase,
+  }) : super(const HomeState.init());
 
   Future<void> fetchProfile() async {
-    final result = await _getProfileUseCase.call();
+    final result = await getProfileUseCase.call();
     if (result is Success<Profile>) {
       _profileImageUrlStream.add(result.value.avatarUrl);
     } else {
@@ -53,7 +56,7 @@ class HomeViewModel extends StateNotifier<HomeState> {
     if (_isEnded) {
       return;
     }
-    final result = await _getSurveysUseCase.call(SurveysParams(
+    final result = await getSurveysUseCase.call(SurveysParams(
       pageNumber: _page,
       pageSize: 5,
     ));
@@ -92,5 +95,9 @@ class HomeViewModel extends StateNotifier<HomeState> {
   void changeFocusedItem({required int index}) {
     _focusedItemIndex = index;
     _focusedItemIndexStream.add(index);
+  }
+
+  Future<void> logOut() async {
+    await logoutUseCase.call();
   }
 }

--- a/lib/views/home/survey_section/survey_list.dart
+++ b/lib/views/home/survey_section/survey_list.dart
@@ -79,13 +79,12 @@ class SurveyList extends StatelessWidget {
     return SafeArea(
       child: RefreshIndicator(
         key: _refreshIndicatorKey,
-        edgeOffset: 100,
         onRefresh: onRefresh,
         child: SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           child: SizedBox(
             width: screenWidth,
-            height: MediaQuery.of(context).size.height - 100,
+            height: MediaQuery.of(context).size.height - 220,
             child: PageView.builder(
               scrollDirection: Axis.horizontal,
               controller: itemController,

--- a/lib/views/login/login_form.dart
+++ b/lib/views/login/login_form.dart
@@ -51,7 +51,7 @@ class LoginFormState extends ConsumerState<LoginForm> {
         ),
       ),
       onPressed: () {
-        context.go(RoutePath.forgetPassword.path);
+        context.goNamed(RoutePath.forgetPassword.name);
       },
     );
   }
@@ -111,6 +111,8 @@ class LoginFormState extends ConsumerState<LoginForm> {
 
   @override
   Widget build(BuildContext context) {
+    _emailController.text = 'kayla@nimblehq.co';
+    _passwordController.text = '12345678';
     return Form(
       key: _loginFormKey,
       autovalidateMode: _isStartedValidation

--- a/lib/views/login/login_form.dart
+++ b/lib/views/login/login_form.dart
@@ -51,7 +51,7 @@ class LoginFormState extends ConsumerState<LoginForm> {
         ),
       ),
       onPressed: () {
-        context.push(RoutePath.forgetPassword.screen);
+        context.push(RoutePath.forgetPassword.path);
       },
     );
   }

--- a/lib/views/login/login_form.dart
+++ b/lib/views/login/login_form.dart
@@ -51,7 +51,7 @@ class LoginFormState extends ConsumerState<LoginForm> {
         ),
       ),
       onPressed: () {
-        context.push(RoutePath.forgetPassword.path);
+        context.go(RoutePath.forgetPassword.path);
       },
     );
   }

--- a/lib/views/login/login_form.dart
+++ b/lib/views/login/login_form.dart
@@ -111,8 +111,6 @@ class LoginFormState extends ConsumerState<LoginForm> {
 
   @override
   Widget build(BuildContext context) {
-    _emailController.text = 'kayla@nimblehq.co';
-    _passwordController.text = '12345678';
     return Form(
       key: _loginFormKey,
       autovalidateMode: _isStartedValidation

--- a/lib/views/survey_detail/survey_detail_state.dart
+++ b/lib/views/survey_detail/survey_detail_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'survey_detail_state.freezed.dart';
+
+@freezed
+class SurveyDetailState with _$SurveyDetailState {
+  const factory SurveyDetailState.init() = _Init;
+
+  const factory SurveyDetailState.loading() = _Loading;
+
+  const factory SurveyDetailState.error(String? error) = _Error;
+
+  const factory SurveyDetailState.success() = _Success;
+}

--- a/lib/views/survey_detail/survey_detail_view.dart
+++ b/lib/views/survey_detail/survey_detail_view.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kayla_flutter_ic/utils/app_bar_ext.dart';
+
+class SurveyDetailView extends ConsumerStatefulWidget {
+  final String surveyId;
+
+  const SurveyDetailView({
+    required this.surveyId,
+    super.key,
+  });
+
+  @override
+  SurveyDetailViewState createState() => SurveyDetailViewState();
+}
+
+class SurveyDetailViewState extends ConsumerState<SurveyDetailView>
+    with TickerProviderStateMixin {
+
+  AppBar get _appBar => AppBarExt.appBarWithBackButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _appBar,
+      body: Container(),
+    );
+  }
+}

--- a/lib/views/survey_detail/survey_detail_view.dart
+++ b/lib/views/survey_detail/survey_detail_view.dart
@@ -16,7 +16,6 @@ class SurveyDetailView extends ConsumerStatefulWidget {
 
 class SurveyDetailViewState extends ConsumerState<SurveyDetailView>
     with TickerProviderStateMixin {
-
   AppBar get _appBar => AppBarExt.appBarWithBackButton;
 
   @override

--- a/lib/views/survey_detail/survey_detail_view.dart
+++ b/lib/views/survey_detail/survey_detail_view.dart
@@ -16,7 +16,7 @@ class SurveyDetailView extends ConsumerStatefulWidget {
 
 class SurveyDetailViewState extends ConsumerState<SurveyDetailView>
     with TickerProviderStateMixin {
-  AppBar get _appBar => AppBarExt.appBarWithBackButton;
+  AppBar get _appBar => AppBarExt.appBarWithBackButton(context: context);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## What happened 👀

Refactor app router.

## Insight 📝

- Split the setup for the app router into new files.
- Change the locations of pages:
  - Home: `/`
  - Login: `/login`
  - Forget password: `/forget-password`
  - Survey detail: `/surveys/:surveyId` with :surveyId will be replaced by the real ID value
- Implement redirect the app to the login screen when user have not logged in the app.

The resources that I followed are:

- https://pub.dev/documentation/go_router/latest/topics/Configuration-topic.html
- https://pub.dev/documentation/go_router/latest/topics/Named%20routes-topic.html
- https://pub.dev/documentation/go_router/latest/topics/Redirection-topic.html
- https://pub.dev/documentation/go_router/latest/topics/Navigation-topic.html

## Proof Of Work 📹

![2023-02-24 13 38 00](https://user-images.githubusercontent.com/23162627/221110110-dd33a156-227d-48be-958e-c5e0838b1de5.gif)

