### PR TITLE
[Draft] [Will not merge] Example for managing submitted answers

### DIFF
--- a/lib/views/question/question_container_view.dart
+++ b/lib/views/question/question_container_view.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:kayla_flutter_ic/utils/durations.dart';
 import 'package:kayla_flutter_ic/utils/route_paths.dart';
 import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_option_ui_model.dart';
+import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_state.dart';
 import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_view.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_state.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_view_model.dart';
@@ -76,6 +77,19 @@ class QuestionContainerViewState extends ConsumerState<QuestionContainerView> {
   }
 
   void _nextQuestion() {
+    // TODO: - Get current answer
+    final choiceState = ref.read(singleChoiceViewModelProvider);
+    choiceState.maybeWhen(
+      orElse: () {},
+      select: (uiModels, selectedIndex) {
+        if (selectedIndex != null) {
+          ref
+              .read(questionViewModelProvider.notifier)
+              .submitCurrentAnswer(uiModels[selectedIndex].title);
+        }
+      },
+    );
+
     context.pushNamed(
       RoutePath.question.name,
       params: _getPathParams(),

--- a/lib/views/question/question_container_view.dart
+++ b/lib/views/question/question_container_view.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'package:kayla_flutter_ic/utils/durations.dart';
 import 'package:kayla_flutter_ic/utils/route_paths.dart';
 import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_option_ui_model.dart';
-import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_state.dart';
 import 'package:kayla_flutter_ic/views/answer/single_choice/single_choice_view.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_state.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_view_model.dart';

--- a/lib/views/question/question_container_view_model.dart
+++ b/lib/views/question/question_container_view_model.dart
@@ -3,6 +3,8 @@ import 'package:kayla_flutter_ic/utils/route_paths.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_state.dart';
 import 'package:kayla_flutter_ic/views/question/question_container_ui_model.dart';
 
+final _answers = <String, String>{};
+
 class QuestionContainerViewModel extends StateNotifier<QuestionContainerState> {
   String get surveyId => _surveyId ?? '';
   int get questionNumber => _questionNumber ?? 0;
@@ -25,6 +27,12 @@ class QuestionContainerViewModel extends StateNotifier<QuestionContainerState> {
       title: surveyId,
     );
     state = QuestionContainerState.success(uiModel);
+  }
+
+  void submitCurrentAnswer(String answer) {
+    // TODO: - Integrate task
+    _answers['$questionNumber'] = answer;
+    print(_answers);
   }
 
   String _setUpSurveyId(Map<String, String> arguments) {

--- a/lib/views/question/question_container_view_model.dart
+++ b/lib/views/question/question_container_view_model.dart
@@ -32,6 +32,7 @@ class QuestionContainerViewModel extends StateNotifier<QuestionContainerState> {
   void submitCurrentAnswer(String answer) {
     // TODO: - Integrate task
     _answers['$questionNumber'] = answer;
+    // ignore: avoid_print
     print(_answers);
   }
 


### PR DESCRIPTION
## What happened 👀

This is the example code for managing submitted answers

## Insight

So I had the `QuestionContainerView` is the parent widget of the `SingleChoiceView`.

When I tap the `Next button`, the `QuestionContainerViewModel` will call `submitCurrentAnswer(...)` function. 

Inside the `QuestionContainerViewModel` file, I define a global variable `_answers` to store the answers. This variable will be clear after submitting answers successfully.

## Proof Of Work 📹

![2023-03-03 09 32 12](https://user-images.githubusercontent.com/23162627/222617204-10c93a9e-79c6-475c-b88c-36aa27e1ae88.gif)

