### PR TITLE
[#29] [UI] As a user, I can see the likert scales question

### DIFF
--- a/lib/model/enum/likert_type.dart
+++ b/lib/model/enum/likert_type.dart
@@ -1,0 +1,28 @@
+enum LikertType {
+  thumbsUp,
+  smiley,
+  heart,
+  star;
+
+  List<String> get icons {
+    switch (this) {
+      case LikertType.thumbsUp:
+        return List.generate(5, (_) => '👍🏻');
+      case LikertType.smiley:
+        return ['😡', '😕', '😐', '🙂', '😄'];
+      case LikertType.heart:
+        return List.generate(5, (_) => '❤️');
+      case LikertType.star:
+        return List.generate(5, (_) => '⭐️');
+    }
+  }
+
+  bool get isSinglyHighlight {
+    switch (this) {
+      case LikertType.smiley:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/lib/views/answer/likert_scale/likert_scale_view.dart
+++ b/lib/views/answer/likert_scale/likert_scale_view.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:kayla_flutter_ic/model/enum/likert_type.dart';
 
 class LikertScaleView extends StatefulWidget {
-  final LikertType uiModel;
+  final LikertType type;
   final Function(int) onSelect;
 
   const LikertScaleView({
     super.key,
-    required this.uiModel,
+    required this.type,
     required this.onSelect,
   });
 
@@ -20,7 +20,7 @@ class _LikertScaleViewState extends State<LikertScaleView> {
 
   List<Widget> get _likertButtons {
     List<Widget> widgets = [];
-    widget.uiModel.icons.asMap().forEach((index, icon) {
+    widget.type.icons.asMap().forEach((index, icon) {
       widgets.add(
         GestureDetector(
           child: Container(
@@ -55,7 +55,7 @@ class _LikertScaleViewState extends State<LikertScaleView> {
   }) {
     if (selectedIndex == null) {
       return Colors.white30;
-    } else if (widget.uiModel.isSinglyHighlight) {
+    } else if (widget.type.isSinglyHighlight) {
       return selectedIndex == index ? Colors.white : Colors.white30;
     } else {
       return selectedIndex >= index ? Colors.white : Colors.white30;
@@ -64,13 +64,10 @@ class _LikertScaleViewState extends State<LikertScaleView> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: MediaQuery.of(context).size.width,
-      child: Center(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: _likertButtons,
-        ),
+    return Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: _likertButtons,
       ),
     );
   }

--- a/lib/views/answer/likert_scale/likert_scale_view.dart
+++ b/lib/views/answer/likert_scale/likert_scale_view.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:kayla_flutter_ic/model/enum/likert_type.dart';
+
+class LikertScaleView extends StatefulWidget {
+  final LikertType uiModel;
+  final Function(int) onSelect;
+
+  const LikertScaleView({
+    super.key,
+    required this.uiModel,
+    required this.onSelect,
+  });
+
+  @override
+  State<LikertScaleView> createState() => _LikertScaleViewState();
+}
+
+class _LikertScaleViewState extends State<LikertScaleView> {
+  int? selectedIndex;
+
+  List<Widget> get _likertButtons {
+    List<Widget> widgets = [];
+    widget.uiModel.icons.asMap().forEach((index, icon) {
+      widgets.add(
+        GestureDetector(
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: SizedBox(
+              width: 34,
+              height: 34,
+              child: FittedBox(
+                fit: BoxFit.contain,
+                child: Text(
+                  icon,
+                  style: TextStyle(
+                    color: _textColor(
+                      selectedIndex: selectedIndex,
+                      index: index,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          onTap: () => _onSelect(index),
+        ),
+      );
+    });
+    return widgets;
+  }
+
+  Color _textColor({
+    required int? selectedIndex,
+    required int index,
+  }) {
+    if (selectedIndex == null) {
+      return Colors.white30;
+    } else if (widget.uiModel.isSinglyHighlight) {
+      return selectedIndex == index ? Colors.white : Colors.white30;
+    } else {
+      return selectedIndex >= index ? Colors.white : Colors.white30;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      child: Center(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: _likertButtons,
+        ),
+      ),
+    );
+  }
+
+  void _onSelect(int index) {
+    setState(() {
+      selectedIndex = index;
+    });
+    widget.onSelect(index);
+  }
+}


### PR DESCRIPTION
- Close #29

## What happened 👀

The user can see the likert scale question and select one option. The likert scale is a scale from 1 to 5, starting at "not at all likely" scaling up to "extremely likely", presenting via 5 thumb-up from left to right on the screen.

The user chooses the answer by tapping on one option.

## Insight 📝

- Smiley: The selected option will be the only option that is highlighted.
- Thumbs up, Heart, Star: It will be range highlighted

## Proof Of Work 📹

<img width=300 src="https://user-images.githubusercontent.com/23162627/222697080-e631eea3-6e9a-4ebc-8234-ea081965717b.gif"> <img width=300 src="https://user-images.githubusercontent.com/23162627/222697145-92c139b4-aa76-4309-966f-a8b5987e5f13.gif"> <img width=300 src="https://user-images.githubusercontent.com/23162627/222697178-88ad374d-9eb3-493a-8706-93be3b81deec.gif"> <img width=300 src="https://user-images.githubusercontent.com/23162627/222697195-73429149-0eeb-4001-84a2-ef0a15ce2eae.gif">
