### PR TITLE
[#120] Bump version to 0.8.0

### DIFF
--- a/.github/workflows/deploy_android_production.yml
+++ b/.github/workflows/deploy_android_production.yml
@@ -38,5 +38,7 @@ jobs:
       with:
         name: Android-Production-Build
         path: build/app/outputs/flutter-apk/app-production-release.apk
+      env:
+          GITHUB_RUN_NUMBER: ${{ secrets.GITHUB_RUN_NUMBER }}
 
     # TODO: Add Firebase later

--- a/.github/workflows/deploy_android_staging.yml
+++ b/.github/workflows/deploy_android_staging.yml
@@ -39,5 +39,7 @@ jobs:
       with:
         name: Android-Staging-Build
         path: build/app/outputs/flutter-apk/app-staging-debug.apk
+      env:
+          GITHUB_RUN_NUMBER: ${{ secrets.GITHUB_RUN_NUMBER }}
     
     # TODO: Add Firebase later

--- a/.github/workflows/deploy_ios_production.yml
+++ b/.github/workflows/deploy_ios_production.yml
@@ -40,3 +40,5 @@ jobs:
     - name: Deploy production build to AppStore
       run: |
         cd ./ios && bundle exec fastlane build_and_upload_app_store_connect_app
+      env:
+          GITHUB_RUN_NUMBER: ${{ secrets.GITHUB_RUN_NUMBER }}

--- a/.github/workflows/deploy_ios_staging.yml
+++ b/.github/workflows/deploy_ios_staging.yml
@@ -46,3 +46,5 @@ jobs:
 
     - name: Deploy to TestFlight
       run: cd ios && bundle exec fastlane build_and_upload_testflight_app
+      env:
+          GITHUB_RUN_NUMBER: ${{ secrets.GITHUB_RUN_NUMBER }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,7 +52,7 @@ android {
         applicationId "com.flutteric.kayla"
         minSdkVersion 23
         targetSdkVersion 31
-        versionCode flutterVersionCode.toInteger()
+        versionCode System.env.GITHUB_RUN_NUMBER?.toInteger() ?: flutterVersionCode.toInteger()
         versionName flutterVersionName
         resValue "string", "build_config_package", "com.flutteric.kayla"
     }

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -123,7 +123,7 @@ platform :ios do
   desc 'set build number with number of commits'
   private_lane :bump_build do
     increment_build_number(
-      build_number: number_of_commits,
+      build_number: ENV["GITHUB_RUN_NUMBER"],
       xcodeproj: Constants.PROJECT_PATH
     )
   end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.7.0+1
+version: 0.8.0+1
 
 environment:
   sdk: ">=2.17.5 <3.0.0"


### PR DESCRIPTION
- Close #120

## What happened 👀

- Bump version to 0.8.0
- Use GITHUB_RUN_NUMBER to set the build version and version code instead of using the pubspec.yaml

## Insight 📝

N/A

## Proof Of Work 📹

N/A
